### PR TITLE
Use Helios when `consensusRpcUrl` is configured

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,3 +1,0 @@
-# Use this if you wish to broadcast transactions
-# https://dashboard.pimlico.io/
-PIMLICO_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ambire-common",
       "version": "2.68.0",
       "dependencies": {
+        "@a16z/helios": "^0.9.0",
         "@lifi/types": "^17.7.1",
         "@metamask/eth-sig-util": "^8.2.0",
         "aes-js": "^3.1.2",
@@ -87,6 +88,29 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@a16z/helios": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@a16z/helios/-/helios-0.9.0.tgz",
+      "integrity": "sha512-Njw3wrYz7T4Pf/d6D0Gi0ISictFaHC3Wu8EekmbLY5GtOWxCXziVtmqyobAet7hM4gZaQAVZ3XIhhjgD8myK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "uuid": "^11.0.5"
+      }
+    },
+    "node_modules/@a16z/helios/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -18245,6 +18269,22 @@
     }
   },
   "dependencies": {
+    "@a16z/helios": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@a16z/helios/-/helios-0.9.0.tgz",
+      "integrity": "sha512-Njw3wrYz7T4Pf/d6D0Gi0ISictFaHC3Wu8EekmbLY5GtOWxCXziVtmqyobAet7hM4gZaQAVZ3XIhhjgD8myK2A==",
+      "requires": {
+        "eventemitter3": "^5.0.1",
+        "uuid": "^11.0.5"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
+        }
+      }
+    },
     "@adraffy/ens-normalize": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ambire-common",
-  "version": "2.67.1",
+  "version": "2.68.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ambire-common",
-      "version": "2.67.1",
+      "version": "2.68.0",
       "dependencies": {
         "@lifi/types": "^17.7.1",
         "@metamask/eth-sig-util": "^8.2.0",
@@ -37,6 +37,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.16.1",
         "@types/node-fetch": "^2.6.11",
+        "@types/react": "^18.1.0",
         "@types/ungap__structured-clone": "^1.2.0",
         "@types/validator": "^13.7.0",
         "@typescript-eslint/eslint-plugin": "5.5.0",
@@ -4934,11 +4935,29 @@
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.3",
@@ -7093,6 +7112,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -21640,11 +21666,27 @@
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true
+    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
+    },
+    "@types/react": {
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "@types/secp256k1": {
       "version": "4.0.3",
@@ -23187,6 +23229,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true
+    },
+    "csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
     "damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "jest": "node runTests.js",
     "build": "tsc src/libs/deployless/deployless.ts -t es5",
     "prettier": "prettier --write 'contracts/**/*.sol'",
-    "lint:fix": "eslint ./src/** --ext .js,.jsx,.ts,.tsx --fix"
+    "lint:fix": "eslint ./src/** --ext .js,.jsx,.ts,.tsx --fix",
+    "check": "tsc --noEmit && echo 'FIXME: eslint is disabled here because there are too many issues.'"
   },
   "dependencies": {
     "@lifi/types": "^17.7.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.16.1",
     "@types/node-fetch": "^2.6.11",
+    "@types/react": "^18.1.0",
     "@types/ungap__structured-clone": "^1.2.0",
     "@types/validator": "^13.7.0",
     "@typescript-eslint/eslint-plugin": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check": "tsc --noEmit && echo 'FIXME: eslint is disabled here because there are too many issues.'"
   },
   "dependencies": {
+    "@a16z/helios": "^0.9.0",
     "@lifi/types": "^17.7.1",
     "@metamask/eth-sig-util": "^8.2.0",
     "aes-js": "^3.1.2",

--- a/src/controllers/accountPicker/accountPicker.test.ts
+++ b/src/controllers/accountPicker/accountPicker.test.ts
@@ -31,7 +31,7 @@ import { AccountPickerController, DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from './acco
 const windowManager = mockWindowManager().windowManager
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 const key1to11BasicAccPublicAddresses = Array.from(

--- a/src/controllers/accounts/accounts.test.ts
+++ b/src/controllers/accounts/accounts.test.ts
@@ -44,7 +44,7 @@ describe('AccountsController', () => {
     }
   ]
   const providers = Object.fromEntries(
-    networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+    networks.map((network) => [network.chainId, getRpcProvider(network)])
   )
 
   const mockKeys = mockInternalKeys(accounts)

--- a/src/controllers/actions/actions.test.ts
+++ b/src/controllers/actions/actions.test.ts
@@ -140,7 +140,7 @@ describe('Actions Controller', () => {
     }
   ]
   const providers = Object.fromEntries(
-    networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+    networks.map((network) => [network.chainId, getRpcProvider(network)])
   )
 
   let providersCtrl: ProvidersController

--- a/src/controllers/activity/activity.test.ts
+++ b/src/controllers/activity/activity.test.ts
@@ -110,7 +110,7 @@ const SIGNED_MESSAGE: SignedMessage = {
 const providers: RPCProviders = {}
 
 networks.forEach((network) => {
-  providers[network.chainId.toString()] = getRpcProvider(network.rpcUrls, network.chainId)
+  providers[network.chainId.toString()] = getRpcProvider(network)
   providers[network.chainId.toString()].isWorking = true
 })
 

--- a/src/controllers/addressBook/addressBook.test.ts
+++ b/src/controllers/addressBook/addressBook.test.ts
@@ -62,7 +62,7 @@ const MOCK_ACCOUNTS: Account[] = [
 storage.set('accounts', MOCK_ACCOUNTS)
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 describe('AddressBookController', () => {

--- a/src/controllers/defiPositions/defiPositions.test.ts
+++ b/src/controllers/defiPositions/defiPositions.test.ts
@@ -37,7 +37,7 @@ const ACCOUNT = {
 const providers: RPCProviders = {}
 
 networks.forEach((network) => {
-  providers[network.chainId.toString()] = getRpcProvider(network.rpcUrls, network.chainId)
+  providers[network.chainId.toString()] = getRpcProvider(network)
   providers[network.chainId.toString()].isWorking = true
 })
 

--- a/src/controllers/domains/domains.test.ts
+++ b/src/controllers/domains/domains.test.ts
@@ -5,7 +5,7 @@ import { getRpcProvider } from '../../services/provider'
 import { DomainsController } from './domains'
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 const ENS = {

--- a/src/controllers/portfolio/portfolio.test.ts
+++ b/src/controllers/portfolio/portfolio.test.ts
@@ -29,7 +29,7 @@ const EMPTY_ACCOUNT_ADDR = '0xA098B9BccaDd9BAEc311c07433e94C9d260CbC07'
 const providers: RPCProviders = {}
 
 networks.forEach((network) => {
-  providers[network.chainId.toString()] = getRpcProvider(network.rpcUrls, network.chainId)
+  providers[network.chainId.toString()] = getRpcProvider(network)
   providers[network.chainId.toString()].isWorking = true
 })
 

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -400,7 +400,7 @@ export class PortfolioController extends EventEmitter {
       !this.#portfolioLibs.has(key) ||
       this.#portfolioLibs.get(key)?.network?.selectedRpcUrl !==
         // eslint-disable-next-line no-underscore-dangle
-        providers[network.chainId.toString()]?._getConnection().url
+        providers[network.chainId.toString()]?.getRpcUrl()
     ) {
       try {
         this.#portfolioLibs.set(

--- a/src/controllers/portfolio/portfolio.ts
+++ b/src/controllers/portfolio/portfolio.ts
@@ -400,7 +400,7 @@ export class PortfolioController extends EventEmitter {
       !this.#portfolioLibs.has(key) ||
       this.#portfolioLibs.get(key)?.network?.selectedRpcUrl !==
         // eslint-disable-next-line no-underscore-dangle
-        providers[network.chainId.toString()]?.getRpcUrl()
+        providers[network.chainId.toString()]?._getConnection().url
     ) {
       try {
         this.#portfolioLibs.set(

--- a/src/controllers/providers/providers.ts
+++ b/src/controllers/providers/providers.ts
@@ -39,7 +39,7 @@ export class ProvidersController extends EventEmitter {
     const provider = this.providers[network.chainId.toString()]
 
     // Only update the RPC if the new RPC is different from the current one or if there is no RPC for this network yet.
-    if (!provider || provider?.getRpcUrl() !== network.selectedRpcUrl) {
+    if (!provider || provider?._getConnection().url !== network.selectedRpcUrl) {
       const oldRPC = this.providers[network.chainId.toString()]
 
       // If an RPC fails once it will try to reconnect every second. If we don't destroy the old RPC it will keep trying to reconnect forever.
@@ -49,11 +49,7 @@ export class ProvidersController extends EventEmitter {
         // no need to do anything; try/catch is just in case a double destroy is attempted
       }
 
-      this.providers[network.chainId.toString()] = getRpcProvider(
-        network.rpcUrls,
-        network.chainId,
-        network.selectedRpcUrl
-      )
+      this.providers[network.chainId.toString()] = getRpcProvider(network)
     }
   }
 

--- a/src/controllers/providers/providers.ts
+++ b/src/controllers/providers/providers.ts
@@ -39,7 +39,7 @@ export class ProvidersController extends EventEmitter {
     const provider = this.providers[network.chainId.toString()]
 
     // Only update the RPC if the new RPC is different from the current one or if there is no RPC for this network yet.
-    if (!provider || provider?._getConnection().url !== network.selectedRpcUrl) {
+    if (!provider || provider?.getRpcUrl() !== network.selectedRpcUrl) {
       const oldRPC = this.providers[network.chainId.toString()]
 
       // If an RPC fails once it will try to reconnect every second. If we don't destroy the old RPC it will keep trying to reconnect forever.

--- a/src/controllers/requests/requests.test.ts
+++ b/src/controllers/requests/requests.test.ts
@@ -94,7 +94,7 @@ const prepareTest = async () => {
   providersCtrl = new ProvidersController(networksCtrl)
   const providers: RPCProviders = {}
   networks.forEach((network) => {
-    providers[network.chainId.toString()] = getRpcProvider(network.rpcUrls, network.chainId)
+    providers[network.chainId.toString()] = getRpcProvider(network)
     providers[network.chainId.toString()].isWorking = true
   })
   providersCtrl.providers = providers

--- a/src/controllers/selectedAccount/selectedAccount.test.ts
+++ b/src/controllers/selectedAccount/selectedAccount.test.ts
@@ -24,7 +24,7 @@ import { StorageController } from '../storage/storage'
 import { DEFAULT_SELECTED_ACCOUNT_PORTFOLIO, SelectedAccountController } from './selectedAccount'
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 const storage: Storage = produceMemoryStore()

--- a/src/controllers/signAccountOp/signAccountOp.test.ts
+++ b/src/controllers/signAccountOp/signAccountOp.test.ts
@@ -47,7 +47,7 @@ import { FeeSpeed, SigningStatus } from './signAccountOp'
 import { SignAccountOpTesterController } from './signAccountOpTester'
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 const createEOAAccountOp = (account: Account) => {
@@ -414,7 +414,7 @@ const init = async (
   const { op } = accountOp
   const network = networksCtrl.networks.find((x) => x.chainId === op.chainId)!
   await portfolio.updateSelectedAccount(account.addr, updateWholePortfolio ? undefined : [network])
-  const provider = getRpcProvider(network.rpcUrls, network.chainId)
+  const provider = getRpcProvider(network)
 
   if (portfolio.getLatestPortfolioState(account.addr)[op.chainId.toString()]!.result) {
     portfolio!.getLatestPortfolioState(account.addr)[op.chainId.toString()]!.result!.tokens = [

--- a/src/controllers/signMessage/signMessage.test.ts
+++ b/src/controllers/signMessage/signMessage.test.ts
@@ -63,7 +63,7 @@ class InternalSigner {
 }
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 const account: Account = {

--- a/src/controllers/swapAndBridge/swapAndBridge.test.ts
+++ b/src/controllers/swapAndBridge/swapAndBridge.test.ts
@@ -71,7 +71,7 @@ const notificationManager = {
 }
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 const storage: Storage = produceMemoryStore()

--- a/src/controllers/transaction/transactionManager.ts
+++ b/src/controllers/transaction/transactionManager.ts
@@ -36,7 +36,7 @@ export class TransactionManagerController extends EventEmitter {
   private registerControllerUpdates(): void {
     this.#controllers.forEach((controller) => {
       controller.onUpdate(async () => {
-        if (controller.toJSON().name === 'TransactionFormState') {
+        if ((controller.toJSON() as unknown as Record<string, unknown>).name === 'TransactionFormState') {
           try {
             await this.handleFormUpdate()
           } catch (error: any) {

--- a/src/controllers/transfer/transfer.test.ts
+++ b/src/controllers/transfer/transfer.test.ts
@@ -42,8 +42,8 @@ const polygon = networks.find((x) => x.chainId === 137n)
 
 if (!ethereum || !polygon) throw new Error('Failed to find ethereum in networks')
 
-const provider = getRpcProvider(ethereum.rpcUrls, ethereum.chainId)
-const polygonProvider = getRpcProvider(polygon.rpcUrls, polygon.chainId)
+const provider = getRpcProvider(ethereum)
+const polygonProvider = getRpcProvider(polygon)
 const PLACEHOLDER_RECIPIENT = '0xc4A6bB5139123bD6ba0CF387828a9A3a73EF8D1e'
 const PLACEHOLDER_SELECTED_ACCOUNT: Account = {
   addr: '0xC2E6dFcc2C6722866aD65F211D5757e1D2879337',
@@ -68,7 +68,7 @@ const polygonPortfolio = new Portfolio(fetch, polygonProvider, polygon, velcroUr
 let transferController: TransferController
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 let providersCtrl: ProvidersController

--- a/src/interfaces/messenger.ts
+++ b/src/interfaces/messenger.ts
@@ -1,6 +1,6 @@
 export type CallbackOptions = {
   /** The sender of the message. */
-  sender: chrome.runtime.MessageSender
+  sender: unknown /* chrome.runtime.MessageSender */
   /** The topic provided. */
   topic: string
   /** An optional scoped identifier. */

--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -62,6 +62,7 @@ export interface Network {
   rpcUrls: string[]
   explorerUrl: string
   selectedRpcUrl: string
+  consensusRpcUrl?: string
   erc4337: NetworkInfo['erc4337']
   rpcNoStateOverride: NetworkInfo['rpcNoStateOverride']
   feeOptions: NetworkInfo['feeOptions']
@@ -74,6 +75,7 @@ export interface Network {
   nativeAssetId: NetworkInfo['nativeAssetId']
   iconUrls?: string[]
   isOptimistic?: NetworkInfo['isOptimistic']
+  isLinea?: boolean
   flagged?: NetworkInfo['flagged']
   predefined: boolean
   wrappedAddr?: string
@@ -86,6 +88,7 @@ export interface Network {
   has7702: boolean
   allowForce4337?: boolean
   disabled?: boolean
+  batchMaxCount?: number
 }
 
 export interface AddNetworkRequestParams {

--- a/src/interfaces/provider.ts
+++ b/src/interfaces/provider.ts
@@ -1,5 +1,10 @@
-import { JsonRpcProvider } from 'ethers'
+import { Provider } from 'ethers'
 
-export type RPCProvider = JsonRpcProvider & { isWorking?: boolean }
+export type RPCProvider = Provider & {
+  send(method: string, params: any[]): Promise<any>
+  request(args: { method: string; params?: any[] }): Promise<any>
+  getRpcUrl(): string
+  isWorking?: boolean
+}
 
 export type RPCProviders = { [chainId: string]: RPCProvider }

--- a/src/interfaces/provider.ts
+++ b/src/interfaces/provider.ts
@@ -2,8 +2,8 @@ import { Provider } from 'ethers'
 
 export type RPCProvider = Provider & {
   send(method: string, params: any[]): Promise<any>
-  request(args: { method: string; params?: any[] }): Promise<any>
-  getRpcUrl(): string
+  request?(args: { method: string; params?: any[] }): Promise<any>
+  _getConnection(): { url: string }
   isWorking?: boolean
 }
 

--- a/src/libs/accountState/accountState.test.ts
+++ b/src/libs/accountState/accountState.test.ts
@@ -20,7 +20,7 @@ import { getAccountState } from './accountState'
 
 const polygon = networks.find((n) => n.chainId === 137n)
 if (!polygon) throw new Error('unable to find polygon network in consts')
-const provider = getRpcProvider(polygon.rpcUrls, polygon.chainId)
+const provider = getRpcProvider(polygon)
 
 describe('AccountState', () => {
   test('should get the account state and check if a v1 address and v2 address (not deployed) are returned correctly', async () => {
@@ -215,7 +215,7 @@ describe('AccountState', () => {
       platformId: 'odyssey',
       has7702: true
     }
-    const odysseyProvider = getRpcProvider(odyssey.rpcUrls, odyssey.chainId)
+    const odysseyProvider = getRpcProvider(odyssey)
     const state = await getAccountState(odysseyProvider, odyssey, [account7702])
 
     expect(state.length).toBe(1)

--- a/src/libs/defiPositions/defiPositions.test.ts
+++ b/src/libs/defiPositions/defiPositions.test.ts
@@ -17,8 +17,15 @@ describe('DeFi positions', () => {
   const polygon = networks.find((n) => n.chainId === 137n)
   if (!polygon) throw new Error('unable to find polygon network in consts')
 
-  const providerEthereum = getRpcProvider(['https://invictus.ambire.com/ethereum'], 1n)
-  const providerPolygon = getRpcProvider(['https://invictus.ambire.com/polygon'], 137n)
+  const providerEthereum = getRpcProvider({
+    rpcUrls: ['https://invictus.ambire.com/ethereum'],
+    chainId: 1n
+  })
+
+  const providerPolygon = getRpcProvider({
+    rpcUrls: ['https://invictus.ambire.com/polygon'],
+    chainId: 137n
+  })
 
   describe('Uni V3', () => {
     test('Get uni v3 positions on Polygon', async () => {

--- a/src/libs/deployless/deployless.test.ts
+++ b/src/libs/deployless/deployless.test.ts
@@ -11,7 +11,10 @@ const helloWorld = compile('HelloWorld', {
   contractsFolder: 'test/contracts'
 })
 const deployErrBin = '0x6080604052348015600f57600080fd5b600080fdfe'
-const mainnetProvider = getRpcProvider(['https://invictus.ambire.com/ethereum'], 1n)
+const mainnetProvider = getRpcProvider({
+  rpcUrls: ['https://invictus.ambire.com/ethereum'],
+  chainId: 1n
+})
 let deployless: Deployless
 
 describe('Deployless', () => {

--- a/src/libs/deployless/simulateDeployCall.ts
+++ b/src/libs/deployless/simulateDeployCall.ts
@@ -1,5 +1,6 @@
-import { JsonRpcProvider, ZeroAddress } from 'ethers'
+import { ZeroAddress } from 'ethers'
 
+import { RPCProvider } from 'interfaces/provider'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import { AMBIRE_ACCOUNT_FACTORY, DEPLOYLESS_SIMULATION_FROM } from '../../consts/deploy'
 import { getSmartAccount, getSpoof } from '../account/account'
@@ -11,7 +12,7 @@ import { DeploylessMode, fromDescriptor } from './deployless'
 // if the call is successful, it means Ambire smart accounts are supported
 // on the given network
 export async function getSASupport(
-  provider: JsonRpcProvider
+  provider: RPCProvider
 ): Promise<{ addressMatches: boolean; supportsStateOverride: boolean }> {
   const smartAccount = await getSmartAccount(
     [

--- a/src/libs/erc7677/erc7677.ts
+++ b/src/libs/erc7677/erc7677.ts
@@ -57,7 +57,10 @@ export function getPaymasterStubData(
   userOp: UserOperation,
   network: Network
 ): Promise<PaymasterEstimationData> {
-  const provider = getRpcProvider([service.url], network.chainId)
+  const provider = getRpcProvider({
+    rpcUrls: [service.url],
+    chainId: network.chainId
+  })
   return provider.send('pm_getPaymasterStubData', [
     getCleanUserOp(userOp)[0],
     ERC_4337_ENTRYPOINT,
@@ -71,7 +74,10 @@ export async function getPaymasterData(
   userOp: UserOperation,
   network: Network
 ): Promise<PaymasterData> {
-  const provider = getRpcProvider([service.url], network.chainId)
+  const provider = getRpcProvider({
+    rpcUrls: [service.url],
+    chainId: network.chainId
+  })
   // TODO<Bobby>: better way to send the bundler
   // send the whole userOp if the sponsorship is from ambire.com
   // so we could fetch the bundler used

--- a/src/libs/estimate/estimate.test.ts
+++ b/src/libs/estimate/estimate.test.ts
@@ -41,11 +41,11 @@ const avalanche = networks.find((x) => x.chainId === 43114n)!
 avalanche.areContractsDeployed = true
 const polygon = networks.find((x) => x.chainId === 137n)
 if (!ethereum || !optimism || !arbitrum || !avalanche || !polygon) throw new Error('no network')
-const provider = getRpcProvider(ethereum.rpcUrls, ethereum.chainId)
-const providerOptimism = getRpcProvider(optimism.rpcUrls, optimism.chainId)
-const providerArbitrum = getRpcProvider(arbitrum.rpcUrls, arbitrum.chainId)
+const provider = getRpcProvider(ethereum)
+const providerOptimism = getRpcProvider(optimism)
+const providerArbitrum = getRpcProvider(arbitrum)
 // const providerAvalanche = getRpcProvider(avalanche.rpcUrls, avalanche.chainId)
-const providerPolygon = getRpcProvider(polygon.rpcUrls, polygon.chainId)
+const providerPolygon = getRpcProvider(polygon)
 const addrWithDeploySignature = '0x52C37FD54BD02E9240e8558e28b11e0Dc22d8e85'
 const errorCallback = () => {}
 
@@ -220,7 +220,7 @@ const feeTokens = [
 const portfolio = new Portfolio(fetch, provider, ethereum, velcroUrl)
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 const getAccountsInfo = async (accounts: Account[]): Promise<AccountStates> => {
   const result = await Promise.all(

--- a/src/libs/estimate/estimateBundler.test.ts
+++ b/src/libs/estimate/estimateBundler.test.ts
@@ -92,7 +92,7 @@ describe('Bundler estimation tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAcc])
 
@@ -154,7 +154,7 @@ describe('Bundler estimation tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccDeployed])
 
@@ -213,7 +213,7 @@ describe('Bundler estimation tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccDeployed])
 
@@ -290,7 +290,7 @@ describe('Bundler fallback tests', () => {
     }
     const usedNetworks = [base]
     const providers = {
-      [base.chainId.toString()]: getRpcProvider(base.rpcUrls, base.chainId)
+      [base.chainId.toString()]: getRpcProvider(base)
     }
     const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccDeployed])
 

--- a/src/libs/estimate/estimateGas.ts
+++ b/src/libs/estimate/estimateGas.ts
@@ -45,12 +45,7 @@ export async function estimateGas(
     .catch(async (e) => {
       if (!e.message.includes('insufficient funds')) return 0n
 
-      const isolatedProvider = getRpcProvider(
-        network.rpcUrls,
-        network.chainId,
-        network.selectedRpcUrl,
-        { batchMaxCount: 1 }
-      )
+      const isolatedProvider = getRpcProvider({ ...network, batchMaxCount: 1 })
       const withOverrides = await isolatedProvider
         .send('eth_estimateGas', [
           {

--- a/src/libs/networks/networks.ts
+++ b/src/libs/networks/networks.ts
@@ -110,7 +110,7 @@ export async function getNetworkInfo(
   }
 
   let flagged = false
-  const provider = getRpcProvider([rpcUrl], chainId)
+  const provider = getRpcProvider({ rpcUrls: [rpcUrl], chainId })
 
   const raiseFlagged = (e: Error, returnData: any): any => {
     if (e.message === 'flagged') {

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -279,7 +279,7 @@ export class Paymaster extends AbstractPaymaster {
         salt: acc.creation?.salt,
         key: acc.associatedKeys[0],
         // eslint-disable-next-line no-underscore-dangle
-        rpcUrl: this.provider!._getConnection().url,
+        rpcUrl: this.provider!.getRpcUrl(),
         bundler: userOp.bundler
       })
     })

--- a/src/libs/paymaster/paymaster.ts
+++ b/src/libs/paymaster/paymaster.ts
@@ -279,7 +279,7 @@ export class Paymaster extends AbstractPaymaster {
         salt: acc.creation?.salt,
         key: acc.associatedKeys[0],
         // eslint-disable-next-line no-underscore-dangle
-        rpcUrl: this.provider!.getRpcUrl(),
+        rpcUrl: this.provider!._getConnection().url,
         bundler: userOp.bundler
       })
     })

--- a/src/libs/portfolio/helpers.test.ts
+++ b/src/libs/portfolio/helpers.test.ts
@@ -13,7 +13,7 @@ const polygon = networks.find((x) => x.chainId === 137n)
 
 if (!ethereum || !polygon) throw new Error('Failed to find ethereum in networks')
 
-const provider = getRpcProvider(ethereum.rpcUrls, ethereum.chainId)
+const provider = getRpcProvider(ethereum)
 
 const ethPortfolio = new Portfolio(fetch, provider, ethereum, velcroUrl)
 

--- a/src/libs/portfolio/portfolio.test.ts
+++ b/src/libs/portfolio/portfolio.test.ts
@@ -21,7 +21,7 @@ import { StrippedExternalHintsAPIResponse } from './interfaces'
 import { Portfolio } from './portfolio'
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 const getAccountsInfo = async (accounts: Account[]): Promise<AccountStates> => {
   const result = await Promise.all(
@@ -50,8 +50,14 @@ describe('Portfolio', () => {
   if (!ethereum) throw new Error('unable to find ethereum network in consts')
   if (!arbitrum) throw new Error('unable to find arbitrum network in consts')
 
-  const provider = getRpcProvider(['https://invictus.ambire.com/ethereum'], 1n)
-  const providerArbitrum = getRpcProvider(['https://invictus.ambire.com/arbitrum'], 42161n)
+  const provider = getRpcProvider({
+    rpcUrls: ['https://invictus.ambire.com/ethereum'],
+    chainId: 1n
+  })
+  const providerArbitrum = getRpcProvider({
+    rpcUrls: ['https://invictus.ambire.com/arbitrum'],
+    chainId: 42161n
+  })
 
   const portfolio = new Portfolio(fetch, provider, ethereum, velcroUrl)
   const portfolioArbitrum = new Portfolio(fetch, providerArbitrum, arbitrum, velcroUrl)

--- a/src/libs/proxyDeploy/bytecode.ts
+++ b/src/libs/proxyDeploy/bytecode.ts
@@ -10,7 +10,7 @@ export async function getBytecode(priLevels: PrivLevels[]): Promise<string> {
   })
 }
 export async function get4437Bytecode(network: Network, priLevels: PrivLevels[]): Promise<string> {
-  const provider = getRpcProvider(network.rpcUrls, network.chainId)
+  const provider = getRpcProvider(network)
   const code = await provider.getCode(PROXY_AMBIRE_4337_ACCOUNT)
   if (code === '0x') throw new Error('No proxy ambire account mined for the specified network')
 

--- a/src/libs/relayerCall/relayerCall.test.ts
+++ b/src/libs/relayerCall/relayerCall.test.ts
@@ -12,7 +12,7 @@ import { getRpcProvider } from '../../services/provider'
 import { relayerCall } from './relayerCall'
 
 const polygon = networks.find((n) => n.chainId === 137n)!
-const provider = getRpcProvider(polygon.rpcUrls, polygon.chainId)
+const provider = getRpcProvider(polygon)
 const callRelayer = relayerCall.bind({ url: relayerUrl, fetch })
 const testAddr = '0x77777777789A8BBEE6C64381e5E89E501fb0e4c8'
 

--- a/src/libs/signMessage/signMessage.test.ts
+++ b/src/libs/signMessage/signMessage.test.ts
@@ -116,7 +116,7 @@ const v1Account: Account = {
 }
 
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 
 const getAccountsInfo = async (accounts: Account[]): Promise<AccountStates> => {
@@ -187,7 +187,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       accountStates[eoaAccount.addr][ethereumNetwork.chainId.toString()],
       signer
     )
-    const provider = getRpcProvider(ethereumNetwork.rpcUrls, ethereumNetwork.chainId)
+    const provider = getRpcProvider(ethereumNetwork)
     const firstRes = await verifyMessage({
       network: ethereumNetwork,
       provider,
@@ -243,7 +243,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     // the key should be dedicatedToOneSA, so we expect the signature to end in 00
     expect(signatureForPlainText.slice(-2)).toEqual('00')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
     const res = await verifyMessage({
       network: polygonNetwork,
       provider,
@@ -272,7 +272,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     // the key should be 00 because it's a v1 account
     expect(signatureForPlainText.slice(-2)).toEqual('00')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
     const res = await verifyMessage({
       network: polygonNetwork,
       provider,
@@ -345,7 +345,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       accountState.accountAddr,
       hashMessage('test')
     )
-    const provider = getRpcProvider(ethereumNetwork.rpcUrls, ethereumNetwork.chainId)
+    const provider = getRpcProvider(ethereumNetwork)
     const eip712Sig = await getEIP712Signature(
       typedDataTest,
       eoaAccount,
@@ -600,7 +600,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
       },
       primaryType: 'BulkOrder'
     }
-    const provider = getRpcProvider(ethereumNetwork.rpcUrls, ethereumNetwork.chainId)
+    const provider = getRpcProvider(ethereumNetwork)
     const eip712Sig = await getEIP712Signature(
       typedDataTest,
       eoaAccount,
@@ -637,7 +637,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     // the key should be dedicatedToOneSA, so we expect the signature to end in 00
     expect(eip712Sig.slice(-2)).toEqual('00')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
     const res = await verifyMessage({
       network: polygonNetwork,
       provider,
@@ -677,7 +677,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     // the key is for a v1 acc so it should be 00
     expect(eip712Sig.slice(-2)).toEqual('00')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
     const res = await verifyMessage({
       network: ethereumNetwork,
       provider,
@@ -705,7 +705,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     // the key is for a v1 acc so it should be 00
     expect(eip712Sig.slice(-2)).toEqual('00')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
     const res = await verifyMessage({
       network: ethereumNetwork,
       provider,
@@ -769,7 +769,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
 
     expect(eip712Sig.slice(-2)).toEqual('02')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
 
     // v2 account
     const contractV2 = new Contract(v2SmartAccAddr, AmbireAccount.abi, provider)
@@ -806,7 +806,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     )
     expect(eip712Sig.slice(-2)).toEqual('00')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
     const wrappedSig = wrapWallet(eip712Sig, smartAccount.addr)
 
     // verify message should pass
@@ -833,7 +833,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
     )
     expect(signatureForPlainText.slice(-2)).toEqual('00')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
     const wrappedSig = wrapWallet(signatureForPlainText, smartAccount.addr)
 
     const res = await verifyMessage({
@@ -879,7 +879,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: true ', () => {
 
     const authorizationHash = getAuthorizationHash(1n, EIP_7702_AMBIRE_ACCOUNT, 0n)
     const signature = signer.sign7702(authorizationHash)
-    const provider = getRpcProvider(ethereumNetwork.rpcUrls, ethereumNetwork.chainId)
+    const provider = getRpcProvider(ethereumNetwork)
     const authorizationRes = await verifyMessage({
       network: ethereumNetwork,
       provider,
@@ -950,7 +950,7 @@ describe('Sign Message, Keystore with key dedicatedToOneSA: false', () => {
     // the key should not be dedicatedToOneSA, so we expect the signature to end in 01
     expect(signatureForPlainText.slice(-2)).toEqual('01')
 
-    const provider = getRpcProvider(polygonNetwork.rpcUrls, polygonNetwork.chainId)
+    const provider = getRpcProvider(polygonNetwork)
     const contract = new Contract(smartAccount.addr, AmbireAccount.abi, provider)
     const isValidSig = await contract.isValidSignature(hashMessage('test'), signatureForPlainText)
     expect(isValidSig).toBe(contractSuccess)

--- a/src/libs/signMessage/signMessage.ts
+++ b/src/libs/signMessage/signMessage.ts
@@ -9,7 +9,6 @@ import {
   hexlify,
   Interface,
   isHexString,
-  JsonRpcProvider,
   keccak256,
   toBeHex,
   toNumber,
@@ -19,6 +18,7 @@ import {
 
 import { MessageTypes, SignTypedDataVersion, TypedDataUtils } from '@metamask/eth-sig-util'
 
+import { RPCProvider } from 'interfaces/provider'
 import UniversalSigValidator from '../../../contracts/compiled/UniversalSigValidator.json'
 import { EIP7702Auth } from '../../consts/7702'
 import { PERMIT_2_ADDRESS, UNISWAP_UNIVERSAL_ROUTERS } from '../../consts/addresses'
@@ -339,7 +339,7 @@ export function mapSignatureV(sigRaw: string) {
 // Either `message` or `typedData` must be provided - never both.
 type Props = {
   network: Network
-  provider: JsonRpcProvider
+  provider: RPCProvider
   signer: string
   signature: string | Uint8Array
 } & (

--- a/src/libs/tracer/debugTraceCall.test.ts
+++ b/src/libs/tracer/debugTraceCall.test.ts
@@ -16,7 +16,10 @@ const ACCOUNT_ADDRESS = '0x46C0C59591EbbD9b7994d10efF172bFB9325E240'
 
 // @TODO add minting and burning test
 describe('Debug tracecall detection for transactions', () => {
-  const provider = getRpcProvider(['https://invictus.ambire.com/optimism'], 10n)
+  const provider = getRpcProvider({
+    rpcUrls: ['https://invictus.ambire.com/optimism'],
+    chainId: 10n
+  })
   let account: Account
   let accountOp: AccountOp
   const nftIface: Interface = new Interface(ERC721)

--- a/src/libs/tracer/debugTraceCall.ts
+++ b/src/libs/tracer/debugTraceCall.ts
@@ -1,5 +1,6 @@
 import { getAddress, Interface, JsonRpcProvider, toQuantity } from 'ethers'
 
+import { RPCProvider } from 'interfaces/provider'
 import AmbireAccount from '../../../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '../../../contracts/compiled/AmbireFactory.json'
 import BalanceGetter from '../../../contracts/compiled/BalanceGetter.json'
@@ -60,7 +61,7 @@ function getFunctionParams(account: Account, op: AccountOp, accountState: Accoun
 export async function debugTraceCall(
   account: Account,
   op: AccountOp,
-  provider: JsonRpcProvider,
+  provider: RPCProvider,
   accountState: AccountOnchainState,
   supportsStateOverride: boolean,
   overrideData?: any

--- a/src/libs/userOperation/userOperation.test.ts
+++ b/src/libs/userOperation/userOperation.test.ts
@@ -54,7 +54,7 @@ describe('User Operation tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccDeployed])
       accountStates[smartAccDeployed.addr][optimism.chainId.toString()].isDeployed = false
@@ -85,7 +85,7 @@ describe('User Operation tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccDeployed])
       const userOp = getUserOperation(
@@ -114,7 +114,7 @@ describe('User Operation tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccDeployed])
       accountStates[smartAccDeployed.addr][optimism.chainId.toString()].isErc4337Enabled = false

--- a/src/services/assetInfo/assetInfo.ts
+++ b/src/services/assetInfo/assetInfo.ts
@@ -13,8 +13,7 @@ const scheduledActions: {
 } = {}
 
 export async function executeBatchedFetch(network: Network): Promise<void> {
-  const rpcUrl = network.selectedRpcUrl || network.rpcUrls[0]
-  const provider = getRpcProvider([rpcUrl], network.chainId)
+  const provider = getRpcProvider(network)
   const allAddresses =
     Array.from(new Set(scheduledActions[network.chainId.toString()]?.data.map((i) => i.address))) ||
     []

--- a/src/services/bundlers/bundler.test.ts
+++ b/src/services/bundlers/bundler.test.ts
@@ -256,7 +256,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [arbitrum]
       const providers = {
-        [arbitrum.chainId.toString()]: getRpcProvider(arbitrum.rpcUrls, arbitrum.chainId)
+        [arbitrum.chainId.toString()]: getRpcProvider(arbitrum)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccNew])
       const accountState = accountStates[opArb.accountAddr][opArb.chainId.toString()]
@@ -302,7 +302,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [arbitrum]
       const providers = {
-        [arbitrum.chainId.toString()]: getRpcProvider(arbitrum.rpcUrls, arbitrum.chainId)
+        [arbitrum.chainId.toString()]: getRpcProvider(arbitrum)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccNew])
       const accountState = accountStates[opArb.accountAddr][opArb.chainId.toString()]
@@ -361,7 +361,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [arbitrum]
       const providers = {
-        [arbitrum.chainId.toString()]: getRpcProvider(arbitrum.rpcUrls, arbitrum.chainId)
+        [arbitrum.chainId.toString()]: getRpcProvider(arbitrum)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccNew])
       const accountState = accountStates[opArb.accountAddr][opArb.chainId.toString()]
@@ -412,7 +412,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAcc])
       const accountState = accountStates[opOptimism.accountAddr][opOptimism.chainId.toString()]
@@ -469,7 +469,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAcc])
       const accountState = accountStates[opOptimism.accountAddr][opOptimism.chainId.toString()]
@@ -535,7 +535,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [optimism]
       const providers = {
-        [optimism.chainId.toString()]: getRpcProvider(optimism.rpcUrls, optimism.chainId)
+        [optimism.chainId.toString()]: getRpcProvider(optimism)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAcc])
       const accountState = accountStates[opOptimism.accountAddr][opOptimism.chainId.toString()]
@@ -584,7 +584,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [baseSepolia]
       const providers = {
-        [baseSepolia.chainId.toString()]: getRpcProvider(baseSepolia.rpcUrls, baseSepolia.chainId)
+        [baseSepolia.chainId.toString()]: getRpcProvider(baseSepolia)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [
         smartAccDeployedOnGnosisButNo4337
@@ -629,7 +629,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [gnosis]
       const providers = {
-        [gnosis.chainId.toString()]: getRpcProvider(gnosis.rpcUrls, gnosis.chainId)
+        [gnosis.chainId.toString()]: getRpcProvider(gnosis)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [
         smartAccDeployedOnGnosisButNo4337
@@ -682,7 +682,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [mantle]
       const providers = {
-        [mantle.chainId.toString()]: getRpcProvider(mantle.rpcUrls, mantle.chainId)
+        [mantle.chainId.toString()]: getRpcProvider(mantle)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAcc])
       const accountState = accountStates[opMantle.accountAddr][opMantle.chainId.toString()]
@@ -739,7 +739,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [mantle]
       const providers = {
-        [mantle.chainId.toString()]: getRpcProvider(mantle.rpcUrls, mantle.chainId)
+        [mantle.chainId.toString()]: getRpcProvider(mantle)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAcc])
       const accountState = accountStates[opMantle.accountAddr][opMantle.chainId.toString()]
@@ -795,7 +795,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [base]
       const providers = {
-        [base.chainId.toString()]: getRpcProvider(base.rpcUrls, base.chainId)
+        [base.chainId.toString()]: getRpcProvider(base)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAcc])
       const accountState = accountStates[opBase.accountAddr][opBase.chainId.toString()]
@@ -845,7 +845,7 @@ describe('Bundler tests', () => {
       }
       const usedNetworks = [base]
       const providers = {
-        [base.chainId.toString()]: getRpcProvider(base.rpcUrls, base.chainId)
+        [base.chainId.toString()]: getRpcProvider(base)
       }
       const accountStates = await getAccountsInfo(usedNetworks, providers, [smartAccDeployed])
       const accountState = accountStates[opBase.accountAddr][opBase.chainId.toString()]

--- a/src/services/bundlers/bundler.ts
+++ b/src/services/bundlers/bundler.ts
@@ -60,7 +60,7 @@ export abstract class Bundler {
    * @param network
    */
   protected getProvider(network: Network): RPCProvider {
-    return getRpcProvider([this.getUrl(network)], network.chainId)
+    return getRpcProvider(network)
   }
 
   private async sendEstimateReq(

--- a/src/services/bundlers/bundlerSwitcher.test.ts
+++ b/src/services/bundlers/bundlerSwitcher.test.ts
@@ -32,7 +32,7 @@ const smartAccDeployed: Account = {
   }
 }
 const providers = Object.fromEntries(
-  networks.map((network) => [network.chainId, getRpcProvider(network.rpcUrls, network.chainId)])
+  networks.map((network) => [network.chainId, getRpcProvider(network)])
 )
 const getAccountsInfo = async (accounts: Account[]): Promise<AccountStates> => {
   const result = await Promise.all(

--- a/src/services/bundlers/etherspot.ts
+++ b/src/services/bundlers/etherspot.ts
@@ -7,6 +7,10 @@ import { Bundler } from './bundler'
 import { GasSpeeds, UserOpStatus } from './types'
 
 export class Etherspot extends Bundler {
+  public shouldReestimateBeforeBroadcast(network: Network): boolean {
+    throw new Error('Method not implemented.')
+  }
+
   protected getUrl(network: Network): string {
     return `https://rpc.etherspot.io/v2/${network.chainId.toString()}?api-key=${
       process.env.REACT_APP_ETHERSPOT_API_KEY

--- a/src/services/ensDomains/ensDomains.ts
+++ b/src/services/ensDomains/ensDomains.ts
@@ -42,7 +42,7 @@ async function resolveENSDomain(domain: string, bip44Item?: number[][]): Promise
   const normalizedDomainName = normalizeDomain(domain)
   if (!normalizedDomainName) return ''
   const ethereum = networks.find((n) => n.chainId === 1n)!
-  const provider = getRpcProvider(ethereum.rpcUrls, ethereum.chainId)
+  const provider = getRpcProvider(ethereum)
   const resolver = await provider.getResolver(normalizedDomainName)
   if (!resolver) return ''
   try {

--- a/src/services/provider/HeliosEthersProvider.ts
+++ b/src/services/provider/HeliosEthersProvider.ts
@@ -1,0 +1,43 @@
+import { createHeliosProvider, HeliosProvider } from '@a16z/helios'
+import { AbstractProvider, Network } from 'ethers'
+import { RPCProvider } from 'interfaces/provider'
+
+export class HeliosEthersProvider extends AbstractProvider implements RPCProvider {
+  rpcUrl: string
+
+  heliosProviderPromise: Promise<HeliosProvider>
+
+  constructor(rpcUrl: string, network?: Network) {
+    super(network)
+
+    this.rpcUrl = rpcUrl
+
+    this.heliosProviderPromise = createHeliosProvider(
+      {
+        // TODO
+      },
+      'ethereum'
+    )
+  }
+
+  // eslint-disable-next-line no-underscore-dangle
+  async _send(method: string, params: unknown[]) {
+    const heliosProvider = await this.heliosProviderPromise
+
+    return heliosProvider.request({ method, params })
+  }
+
+  send(method: string, params: any[] = []) {
+    // eslint-disable-next-line no-underscore-dangle
+    return this._send(method, params)
+  }
+
+  request({ method, params = [] }: { method: string; params: any[] }) {
+    // eslint-disable-next-line no-underscore-dangle
+    return this._send(method, params)
+  }
+
+  getRpcUrl() {
+    return this.rpcUrl
+  }
+}

--- a/src/services/provider/HeliosEthersProvider.ts
+++ b/src/services/provider/HeliosEthersProvider.ts
@@ -1,22 +1,40 @@
-import { createHeliosProvider, HeliosProvider } from '@a16z/helios'
+import { createHeliosProvider, HeliosProvider, NetworkKind } from '@a16z/helios'
 import { AbstractProvider, Network } from 'ethers'
 import { RPCProvider } from 'interfaces/provider'
+import type { MinNetworkConfig } from './getRpcProvider'
 
 export class HeliosEthersProvider extends AbstractProvider implements RPCProvider {
+  config: MinNetworkConfig
+
   rpcUrl: string
 
   heliosProviderPromise: Promise<HeliosProvider>
 
-  constructor(rpcUrl: string, network?: Network) {
-    super(network)
+  constructor(config: MinNetworkConfig, rpcUrl: string, staticNetwork?: Network) {
+    super(staticNetwork)
 
+    this.config = config
     this.rpcUrl = rpcUrl
+
+    let kind: NetworkKind
+
+    if (config.isOptimistic) {
+      kind = 'opstack'
+    } else if (config.isLinea) {
+      kind = 'linea'
+    } else {
+      kind = 'ethereum'
+    }
 
     this.heliosProviderPromise = createHeliosProvider(
       {
-        // TODO
+        executionRpc: rpcUrl,
+        consensusRpc: config.consensusRpcUrl
+        // network: "mainnet" | "goerli" | "sepolia" | ...
+        // FIXME: network apparently defaults to mainnet, so we need to specify
+        //        otherwise?
       },
-      'ethereum'
+      kind
     )
   }
 
@@ -37,7 +55,8 @@ export class HeliosEthersProvider extends AbstractProvider implements RPCProvide
     return this._send(method, params)
   }
 
-  getRpcUrl() {
-    return this.rpcUrl
+  // eslint-disable-next-line no-underscore-dangle
+  _getConnection() {
+    return { url: this.rpcUrl }
   }
 }

--- a/src/services/provider/getRpcProvider.ts
+++ b/src/services/provider/getRpcProvider.ts
@@ -1,26 +1,21 @@
-import { Network } from 'ethers'
+import { JsonRpcProvider, Network } from 'ethers'
 
-import { Network as NetworkInterface } from '../../interfaces/network'
+import { Network as NetworkConfig } from '../../interfaces/network'
 import { HeliosEthersProvider } from './HeliosEthersProvider'
 
-interface ProviderOptions {
-  batchMaxCount: number
+export type MinNetworkConfig = Partial<NetworkConfig> & {
+  rpcUrls: string[]
 }
 
-const getRpcProvider = (
-  rpcUrls: NetworkInterface['rpcUrls'],
-  chainId?: bigint | number,
-  selectedRpcUrl?: string,
-  options?: ProviderOptions
-) => {
-  if (!rpcUrls.length) {
+const getRpcProvider = (config: MinNetworkConfig) => {
+  if (!config.rpcUrls.length) {
     throw new Error('rpcUrls must be a non-empty array')
   }
 
-  let rpcUrl = rpcUrls[0]
+  let rpcUrl = config.rpcUrls[0]
 
-  if (selectedRpcUrl) {
-    const prefUrl = rpcUrls.find((u) => u === selectedRpcUrl)
+  if (config.selectedRpcUrl) {
+    const prefUrl = config.rpcUrls.find((u) => u === config.selectedRpcUrl)
     if (prefUrl) rpcUrl = prefUrl
   }
 
@@ -28,17 +23,20 @@ const getRpcProvider = (
     throw new Error('Invalid RPC URL provided')
   }
 
-  if (chainId) {
-    const staticNetwork = Network.from(Number(chainId))
+  let staticNetwork: Network | undefined
 
-    if (staticNetwork) {
-      // return new JsonRpcProvider(rpcUrl, staticNetwork, { staticNetwork, ...options })
-      return new HeliosEthersProvider(rpcUrl, staticNetwork)
-    }
+  if (config.chainId) {
+    staticNetwork = Network.from(Number(config.chainId))
   }
 
-  // return new JsonRpcProvider(rpcUrl)
-  return new HeliosEthersProvider(rpcUrl)
+  if (config.consensusRpcUrl) {
+    return new HeliosEthersProvider(config, rpcUrl, staticNetwork)
+  }
+
+  return new JsonRpcProvider(rpcUrl, staticNetwork, {
+    staticNetwork,
+    batchMaxCount: config.batchMaxCount
+  })
 }
 
 export { getRpcProvider }

--- a/src/services/provider/getRpcProvider.ts
+++ b/src/services/provider/getRpcProvider.ts
@@ -1,6 +1,7 @@
-import { JsonRpcProvider, Network } from 'ethers'
+import { Network } from 'ethers'
 
 import { Network as NetworkInterface } from '../../interfaces/network'
+import { HeliosEthersProvider } from './HeliosEthersProvider'
 
 interface ProviderOptions {
   batchMaxCount: number
@@ -31,11 +32,13 @@ const getRpcProvider = (
     const staticNetwork = Network.from(Number(chainId))
 
     if (staticNetwork) {
-      return new JsonRpcProvider(rpcUrl, staticNetwork, { staticNetwork, ...options })
+      // return new JsonRpcProvider(rpcUrl, staticNetwork, { staticNetwork, ...options })
+      return new HeliosEthersProvider(rpcUrl, staticNetwork)
     }
   }
 
-  return new JsonRpcProvider(rpcUrl)
+  // return new JsonRpcProvider(rpcUrl)
+  return new HeliosEthersProvider(rpcUrl)
 }
 
 export { getRpcProvider }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { BaseContract, getBytes, hexlify, JsonRpcProvider } from 'ethers'
+import { BaseContract, getBytes, hexlify } from 'ethers'
 import { ethers } from 'hardhat'
 import secp256k1 from 'secp256k1'
 
@@ -7,7 +7,7 @@ import { Account, AccountStates } from '../src/interfaces/account'
 import { Hex } from '../src/interfaces/hex'
 import { Key } from '../src/interfaces/keystore'
 import { Network } from '../src/interfaces/network'
-import { RPCProviders } from '../src/interfaces/provider'
+import { RPCProvider, RPCProviders } from '../src/interfaces/provider'
 import { Storage } from '../src/interfaces/storage'
 import { isSmartAccount } from '../src/libs/account/account'
 import { getAccountState } from '../src/libs/accountState/accountState'
@@ -58,7 +58,7 @@ function getTimelockData(recoveryInfo = defaultRecoveryInfo) {
   return { hash, timelockAddress }
 }
 
-async function getNonce(ambireAccountAddr: string, provider: JsonRpcProvider) {
+async function getNonce(ambireAccountAddr: string, provider: RPCProvider) {
   const accountContract = new ethers.Contract(ambireAccountAddr, AmbireAccount.abi, provider)
   return accountContract.nonce()
 }

--- a/v1/services/dappCatalog/dappCatalogUtils.ts
+++ b/v1/services/dappCatalog/dappCatalogUtils.ts
@@ -1,7 +1,10 @@
 import { fetchCaught } from '../fetch'
 import { AmbireDappManifest, SupportedWeb3Connectivity } from './types'
 
+type NetworkId = number
+
 export const chainIdToWalletNetworkId = (chainId: number): NetworkId | null => {
+  throw new Error('Not implemented')
   // TODO: v2
   // return networks.find((n) => n.chainId === chainId)?.id || null
 }


### PR DESCRIPTION
- Includes 'Fix ts errors' originally proposed separately: https://github.com/ethereum/kohaku-commons/pull/16
- Tidies up `getRpcProvider` by accepting the fields from `Network` as the only parameter, with only `rpcUrls` required
- Adds `HeliosEthersProvider` as a compatible wrapper of `HeliosProvider` within the `ethers` system (by implementing `AbstractProvider`)
- Uses `HeliosEthersProvider` when `consensusRpcUrl` is present (eg `https://ethereum.operationsolarstorm.org`)

TODO: This causes test failures, but they are difficult to navigate due to pre-existing test failures, including tests which sometimes pass and sometimes fail. See https://github.com/ethereum/kohaku-commons/commit/614cfd7de97dd14d5ca57f0f595a63b9bd35295c for details of pre-existing tests which fail some or all the time. Cherry-picking this commit can be useful for identifying additional test failures in this branch.